### PR TITLE
Add React SPA with PWA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 # Быт (Byt)
 
 Простое офлайн-веб‑приложение для учёта домашних дел.
+Интерфейс построен на React и работает как PWA.
 
 ## Архитектура
 
 - **Backend**: Node.js без внешних зависимостей. Данные хранятся в файле `data/db.json`.
-- **Frontend**: простая страница на JavaScript с поддержкой PWA (service worker и manifest).
+- **Frontend**: React (через CDN) и небольшое SPA с React Router.
 
 ## Запуск
 
 ```sh
-node index.js
+npm install
+npm start
 ```
 
-Приложение откроется на `http://localhost:3000`.
+Сервер стартует на `http://localhost:3000`.
 
 ## Компоненты
 
-- `index.js` – минимальный HTTP‑сервер и API `/api/houses`.
-- `public/` – статические файлы интерфейса.
+- `index.js` – минимальный HTTP‑сервер и API `/api/houses` и связанные маршруты.
+  - `public/` – статические файлы интерфейса.
   - `index.html` – основная страница.
   - `app.js` – логика UI.
   - `style.css` – стили (тёмная тема).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "byt-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "byt-app",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"No tests\"",
-    "start": "node index.js"
+    "start": "node index.js",
+    "dev": "node index.js",
+    "build": "echo 'no build step'"
   },
   "keywords": [],
   "author": "",

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,9 @@
   <link rel="manifest" href="/manifest.json">
   <link rel="stylesheet" href="/style.css">
   <title>Быт</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-router-dom@5/umd/react-router-dom.min.js"></script>
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
## Summary
- rewrite frontend using React + React Router via CDN
- extend API to manage houses, rooms and items
- ensure service worker is registered and manifest present
- document new start instructions

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684ef60db75c8332b368be421e240a31